### PR TITLE
Adding sendgrid first testing endpoint

### DIFF
--- a/docs/_docs/development/setup.md
+++ b/docs/_docs/development/setup.md
@@ -91,6 +91,26 @@ if you use FedEx and want to add a Customer_Reference field, define this in your
 SHIPPO_CUSTOMER_REFERENCE="1111111-1-DENRC"
 ```
 
+### SendGrid Secrets
+
+To send PDFs (and other emails) from the server, we use SendGrid. This means
+that you need to [sign up](https://app.sendgrid.com/) for an account (the basic account with 100 emails
+per day is free) and then add the `SENDGRID_API_KEY` to your settings/config.py:
+
+```python
+SENDGRID_API_KEY=xxxxxxxxxxxxxxx
+```
+
+To create your key:
+
+ 1. Go to [SendGrid](https://app.sendgrid.com/) and click on Settings -> Api keys in the left bar
+ 2. Click the blue button to "Create API key"
+ 3. Give your key a meaningful name (e.g., freegenes_dev_test)
+ 4. Choose "Restricted Access" and give "Full Access" to mail send by clicking the bar on the far right circle.
+ 5. Copy it to a safe place, likely your settings/config.py (it is only shown once!)
+
+If the value is found to be None, emails will not be sent.
+
 ### Twist Secrets
 
 The [Twist API](https://twistapi.docs.apiary.io) is an optional integration
@@ -319,7 +339,7 @@ ensuring that the `DOMAIN_NAME` above uses https. It's up to the deployer to set
 
 You need to define a FreeGenes node uri, and different contact information:
 
-> **Important** The `HELP_CONTACT_EMAIL` and `HELP_CONTACT_PHONE` are used for the Shippo API. Ensure that both are valid contacts that can be received by lab personell. The `NODE_INSTITUTION` is also used for the company field.
+> **Important** The `HELP_CONTACT_EMAIL` and `HELP_CONTACT_PHONE` are used for the Shippo API, and the `HELP_CONTACT_EMAIL` is used for SendGrid (if you provide an api key for it). Ensure that both are valid contacts that can be received by lab personell. The `NODE_INSTITUTION` is also used for the company field.
 
 ```python
 HELP_CONTACT_EMAIL = 'vsochat@stanford.edu'

--- a/fg/apps/orders/email.py
+++ b/fg/apps/orders/email.py
@@ -1,0 +1,98 @@
+'''
+
+Copyright (C) 2019 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'''
+
+from fg.settings import (
+    SENDGRID_API_KEY,
+    HELP_CONTACT_EMAIL
+)
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import (
+    Mail,
+    Attachment,
+    FileContent,
+    FileName,
+    FileType,
+    Disposition,
+    ContentId
+)
+
+import base64
+import os
+import json
+import urllib.request as urllib
+
+
+def send_email(email_to, message, subject, 
+               attachment=None, 
+               filetype='application/pdf',
+               filename=None):
+    '''given an email, a message, and an attachment, and a SendGrid API key is defined in
+       settings, send an attachment to the user
+
+       Parameters
+       ==========
+       email_to: the email to send the message to
+       message: the html content for the body
+       subject: the email subject
+       attachment: the attachment file on the server
+    '''
+    if not SENDGRID_API_KEY or not HELP_CONTACT_EMAIL:
+        return
+
+    message = Mail(
+        from_email=HELP_CONTACT_EMAIL,
+        to_emails=email_to,
+        subject=subject,
+        html_content=message)
+
+    # If the user has provided an attachment, add it
+    if attachment:
+        message.attachment = generate_attachment(filepath=attachment,
+                                                 filetype=filetype,
+                                                 filename=filename)
+
+    try:
+        client = SendGridAPIClient(SENDGRID_API_KEY)
+        response = client.send(message)
+        print(response.status_code)
+        print(response.headers)
+    except Exception as e:
+        print(e.message)
+
+
+def generate_attachment(filepath, filetype='application/pdf', filename=None):
+    '''given a filepath, generate an attachment object for SendGrid by reading
+       it in and encoding in base64.
+ 
+       Parameters
+       ==========
+       filepath: the file path to attach on the server.
+       filetype: MIME content type (defaults to application/pdf)
+       filename: a filename for the attachment (defaults to basename provided)
+    '''
+    if not os.path.exists(filepath):
+        return
+
+    # Read in the attachment, base64 encode it
+    with open(filepath, 'rb') as filey:
+        data = filey.read()
+
+    # The filename can be provided, or the basename of actual file
+    if not filename:
+        filename = os.path.basename(filepath)
+
+    encoded = base64.b64encode(data).decode()
+    attachment = Attachment()
+    attachment.file_content = FileContent(encoded)
+    attachment.file_type = FileType(filetype)
+    attachment.file_name = FileName(filename)
+    attachment.disposition = Disposition('attachment')
+    return attachment

--- a/fg/settings/config.py
+++ b/fg/settings/config.py
@@ -38,6 +38,10 @@ FREEGENES_TWIST_TOKEN=None
 FREEGENES_TWIST_EUTOKEN=None
 FREEGENES_TWIST_EMAIL=None
 
+# SendGrid
+
+SENDGRID_API_KEY=None
+
 # DOMAIN NAMES
 ## IMPORTANT: if/when you switch to https, you need to change "DOMAIN_NAME"
 # to have https, otherwise some functionality will not work (e.g., GitHub webhooks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ requests-toolbelt
 retrying
 rq-scheduler
 shapely
+sendgrid==6.1.0
 sentry-sdk==0.11.2
 shippo==2.0.0rc1
 social-auth-app-django


### PR DESCRIPTION
This will be the first PR to add an (initial) test of SendGrid. Since we need to verify that sending works as expected, right now when an MTA is uploaded (the second time, signed by the lab institution) it will send an email (again to the lab). We should be able to track this in [the email activity interface](https://app.sendgrid.com/email_activity) provided by SendGrid for the lab's account.

@hverdonk I'll let you know when this is active, and to test you would want to:

 - Go to an order page, and click on "Upload Signed MTA"
 - re-upload the signed MTA, fill out the form (it won't hurt to do this over with an already signed document)
 - confirm that the email is sent

Testing locally, I first had success, and the second time my IP address was blocked by sendgrid (I think because it's from a wireless router OR repeated send, not sure) so fingers crossed the request will go through! The good news is that we have full logging in SendGrid, so we'll know exactly what's up.

I'll let you know when the server is updated - will take me a few minutes. If/when this works, we can discuss what other functions should be moved to using SendGrid instead of formspree.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>