### PR TITLE
Adding create, delete, update endpoints

### DIFF
--- a/fg/apps/api/urls/permissions.py
+++ b/fg/apps/api/urls/permissions.py
@@ -8,17 +8,17 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import (
+    BasePermission, 
+    SAFE_METHODS
+)
 
 class IsStaffOrSuperUser(BasePermission):
     '''Allows access to staff (admin) or superuser.
     '''
     def has_permission(self, request, view):
 
-        # List and read are always allowed for non staff / superuser
-        if view.action in ['list', 'read']:
+        if request.user.is_staff or request.user.is_superuser:
             return True
 
-        is_staff = request.user.is_staff or request.user.is_superuser
-        return bool(request.user and is_staff)
-
+        return request.method in SAFE_METHODS

--- a/fg/apps/api/urls/routers.py
+++ b/fg/apps/api/urls/routers.py
@@ -41,15 +41,22 @@ from fg.apps.api.urls.serializers import (
 router = routers.DefaultRouter()
 router.register(r'^authors', AuthorViewSet, base_name="author")
 router.register(r'^containers', ContainerViewSet, base_name="container")
+router.register(r'^collections', CollectionViewSet, base_name="collection")
 router.register(r'^compositeparts', CompositePartViewSet, base_name="compositepart")
 router.register(r'^distributions', DistributionViewSet, base_name="distribution")
 router.register(r'^institutions', InstitutionViewSet, base_name="institution")
+router.register(r'^modules', ModuleViewSet, base_name="module")
 router.register(r'^operations', OperationViewSet, base_name="operation")
 router.register(r'^orders', OrderViewSet, base_name="order")
 router.register(r'^organisms', OrganismViewSet, base_name="organism")
+router.register(r'^parts', PartViewSet, base_name="part")
 router.register(r'^plans', PlanViewSet, base_name="plan")
+router.register(r'^platesets', PlateSetViewSet, base_name="plateset")
+router.register(r'^plates', PlateViewSet, base_name="plate")
+router.register(r'^protocols', ProtocolViewSet, base_name="protocol")
 router.register(r'^robots', RobotViewSet, base_name="robots")
 router.register(r'^schemas', SchemaViewSet, base_name="schemas")
+router.register(r'^samples', SampleViewSet, base_name="samples")
 router.register(r'^tags', TagViewSet, base_name="tag")
 
 urlpatterns = [
@@ -57,28 +64,5 @@ urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api-token-auth/', authviews.obtain_auth_token),
-
-    # Viewsets defined here have different serializers for single vs. list views
-
-    url(r'^collections/?$', CollectionViewSet.as_view()),
-    url(r'^collections/(?P<id>.+?)/?$', CollectionViewSet.as_view()),
-
-    url(r'^modules/?$', ModuleViewSet.as_view()),
-    url(r'^modules/(?P<id>.+?)/?$', ModuleViewSet.as_view()),
-
-    url(r'^parts/?$', PartViewSet.as_view()),
-    url(r'^parts/(?P<id>.+?)/?$', PartViewSet.as_view()),
-
-    url(r'^plates/?$', PlateViewSet.as_view()),
-    url(r'^plates/(?P<id>.+?)/?$', PlateViewSet.as_view()),
-
-    url(r'^platesets/?$', PlateSetViewSet.as_view()),
-    url(r'^platesets/(?P<id>.+?)/?$', PlateSetViewSet.as_view()),
-
-    url(r'^protocols/?$', ProtocolViewSet.as_view()),
-    url(r'^protocols/(?P<id>.+?)/?$', ProtocolViewSet.as_view()),
-
-    url(r'^samples/?$', SampleViewSet.as_view()),
-    url(r'^samples/(?P<id>.+?)/?$', SampleViewSet.as_view()),
 
 ]

--- a/fg/apps/main/models/__init__.py
+++ b/fg/apps/main/models/__init__.py
@@ -323,7 +323,7 @@ class Collection(models.Model):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     time_created = models.DateTimeField('date created', auto_now_add=True) 
     time_updated = models.DateTimeField('date modified', auto_now=True)
-    name = models.CharField(max_length=250, blank=False)
+    name = models.CharField(max_length=250, blank=False, unique=True)
 
     # This was originally the collection "README"
     description = models.CharField(max_length=5000, blank=False)
@@ -537,7 +537,7 @@ class Module(models.Model):
     # move any associated modules to belong to the container parent. The root
     # container is not allowed to be deleted.
     container = models.ForeignKey('Container', on_delete=models.DO_NOTHING, blank=False)
-    name = models.CharField(max_length=250, blank=False, validators=[validate_name])
+    name = models.CharField(max_length=250, blank=False, validators=[validate_name], unique=True)
 
     # This is generally bad practice to have a notes field - what is this for?
     notes = models.CharField(max_length=500)
@@ -921,11 +921,6 @@ class Sample(models.Model):
         ('Mutated', 'Mutated')
     ]
 
-    COLLABORATOR_CHOICES = [
-        ('OUTSIDE', True), 
-        ('WITHIN_INSTITUTION', False)
-    ]
-
     SAMPLE_TYPE = [
         ('Plasmid', 'Plasmid'),
         ('Illumina_Library', 'Illumina_Library')
@@ -950,7 +945,7 @@ class Sample(models.Model):
     ]
 
     # Default is outside collaborator (more conservative)
-    outside_collaborator = models.BooleanField(choices=COLLABORATOR_CHOICES, default=True)
+    outside_collaborator = models.BooleanField(default=True)
 
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     sample_type = models.CharField(max_length=32, choices=SAMPLE_TYPE, blank=True, null=True)
@@ -1160,7 +1155,8 @@ class Plan(models.Model):
 
     # If a parent plan is deleted, it's children are meaningless, however
     # a plan that is executed cannot be deleted (see plan pre_delete signal).
-    parent = models.ForeignKey('Plan', on_delete=models.CASCADE)
+    # a plan does not necessarily require a parent
+    parent = models.ForeignKey('Plan', on_delete=models.CASCADE, blank=True, null=True)
 
     # An operation with plans cannot be deleted
     operation = models.ForeignKey('Operation', on_delete=models.PROTECT)


### PR DESCRIPTION
This will add complete create, delete, update/patch endpoints to the server, to go along with [client functions](https://vsoch.github.io/freegenes-python/docs/getting-started/python-client#post-create-endpoints) for create and delete. I had to refactor the custom list/get model to be standard ModelViewSets, as you can't easily (as much as I tried) define the views separately with mixins, and then combine them into a shared url. This should serve the same functionality, the only difference being that all data for a model is returned for a get vs. list, which is probably more desired by users anyway.

This will close #68 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>