### PR TITLE
Added "World" to container types

### DIFF
--- a/fg/apps/main/models/__init__.py
+++ b/fg/apps/main/models/__init__.py
@@ -376,6 +376,7 @@ class Container(models.Model):
          ('rack', 'rack'),
          ('incubator', 'incubator'),
          ('shaking_incubator', 'shaking incubator'),
+         ('world', 'world'),
     ]
 
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)


### PR DESCRIPTION
Added "world" as a CONTAINER_TYPE. This is to make containers for plates that we've shipped out. 

(Also, first pull request, so wanted it to be simple)