### PR TITLE
Adding pre_delete signal for plates

### DIFF
--- a/fg/apps/main/apps.py
+++ b/fg/apps/main/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
-
-class ApiConfig(AppConfig):
+class MainAppConfig(AppConfig):
     name = 'main'
+
+    def ready(self):
+        import fg.apps.main.models.signals


### PR DESCRIPTION
This pull request will do the following:

 - add a "pre_delete" signal for plates to ensure that associated wells (not linked to another plate, which likely should not happen anyway) are deleted.
 - import signals into the models file so they are properly registered!

@Koeng101 I want to quickly show you this, because you asked previously about well generation for plates - and in fact it was set up to do with signals, but the signals were not properly imported into the models file so it wasn't working. And after testing, I decided to remove the post signal and instead provide the "auto create" as a function. Here is a quick overview of how this works.

## Plate Creation

By default, when you create a plate there are not wells added. For example, here we instantiate a model without any wells:

```
from fg.apps.main.models import *                                       

not_saved = Plate(container=Container.objects.last(), name="not-saved")             
not_saved.wells.count()                                                 
0

saved = Plate.objects.create(container=Container.objects.last(), name="saved")                                                                  
saved.wells.count()                                                     
0
```
TLDR: it doesn't matter how you do it - the wells aren't automatically added. I realized this is essential to have because when we are generating plates, we first need to save them to add them to a FactoryOrder, and if we had an "auto create" function it would lead to a circular mess of not being able to add to any model without save, but with save creating wells that were wrong.

So for the above you would create your wells manually, and then add them, of course the plate would need to be saved:

```python
for well in wells:
    saved.add(well)
```

### Plate Wells Deletion

Now here is what this PR is adding (and we can test!) After a plate is deleted, the wells should be too. Here is a plate:

```python
plate
<Plate:<Container:Shelf_1>,plate2>

plate.wells.all()                                                       
Out[4]: <QuerySet [<Well:A1>, <Well:A2>, <Well:A3>, <Well:A4>, <Well:A5>, <Well:A6>, <Well:A7>, <Well:A8>, <Well:A9>, <Well:A10>, <Well:A11>, <Well:A12>, <Well:A13>, <Well:A14>, <Well:A15>, <Well:A16>, <Well:A17>, <Well:A18>, <Well:A19>, <Well:A20>, '...(remaining elements truncated)...']>
```
Let's grab a random well and look at it's uuid, and we will verify it doesn't exist after deleting the plate.

```python
well=plate.wells.last()                                                 

well.uuid                                                               
UUID('fe55b827-d0b4-4e4e-b3c0-a369724729aa')
```
It exists

```python
Well.objects.get(uuid=str(well.uuid))                                   
<Well:J24>
```
Now let's delete the plate

```python
plate.delete()                                                          
```

And confirm that the well doesn't exist

```python
Well.objects.get(uuid=str(well.uuid))                                   
...
DoesNotExist: Well matching query does not exist.
```

### Plate Wells Create Function

But the functionality to generate (empty) wells is still useful, so here is how you use the function. Again, let's use the saved plate we had above with 0 wells:

We start with 0 wells. The number of wells should be length by height

```python
plate.wells.count()
0

plate.length                                                           
24

plate.height                                                           
16

plate.length*plate.height                                             
384
```
Call the function!

```python
plate.generate_wells()                                                
```
Now we have wells!
```python
plate.wells.count()                                                   
384
```

This is also better to not do automatically, as taking the wells takes a pause of time to do, and wherever we expose the function we would want it run as a concurrent task.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>