### PR TITLE
Refactoring Order -> Shipment Workflow

### DIFF
--- a/docs/_docs/usage/interface.md
+++ b/docs/_docs/usage/interface.md
@@ -56,12 +56,10 @@ A successful upload redirects the user to the actual Checkout form.
 
 ![checkout.png]({{ site.baseurl }}/docs/usage/img/checkout.png)
 
-The checkout form itself doesn't save personal information to the server,
-but rather sends an email with the form to the lab. This is done for three reasons -
-
- 1. It's an easy way to notify the lab of an order
- 2. It eliminates the need to store personal information on the server
- 3. We can have better certainty of having the latest shipping information.
+The checkout form saves the lab address and shipping address associated with
+the order to the database, and uses SendGrid to notify the lab of a new order.
+The link to the order is included in the email for the lab to continue processing
+the shipment.
 
 
 ## Factory

--- a/fg/apps/orders/forms.py
+++ b/fg/apps/orders/forms.py
@@ -32,8 +32,12 @@ class CheckoutForm(forms.Form):
     lab_name = forms.CharField(required=True)
     lab_address = forms.CharField(required=True)
     lab_address2 = forms.CharField(required=False)
-    lab_zip = forms.CharField(required=True)
+    lab_zip = forms.CharField(required=True, label="Postal Code")
     lab_phone = forms.CharField(required=True)
+    lab_city = forms.CharField(required=True)
+    lab_state = forms.CharField(required=True)
+    lab_email = forms.CharField(required=True)
+    lab_country = forms.CharField(required=True)
 
     # PI Name and title (signing the MTA)
     recipient_name = forms.CharField(required=True)
@@ -46,8 +50,11 @@ class CheckoutForm(forms.Form):
     shipping_to = forms.CharField(required=False)
     shipping_address = forms.CharField(required=False)
     shipping_address2 = forms.CharField(required=False)
-    shipping_zip = forms.CharField(required=False)
+    shipping_zip = forms.CharField(required=False, label="Postal Code")
     shipping_phone = forms.CharField(required=False)
+    shipping_state = forms.CharField(required=False)
+    shipping_city = forms.CharField(required=False)
+    shipping_country = forms.CharField(required=False)
 
 
 DRY_ICE_CHOICES = (

--- a/fg/apps/orders/templates/orders/checkout.html
+++ b/fg/apps/orders/templates/orders/checkout.html
@@ -8,7 +8,9 @@
       <div class="row">
         <div class="col-md-8 mb-4">
 
-	<form action="https://formspree.io/{{ HELP_CONTACT_EMAIL }}" method="POST" class="card-body">
+	<form action="{% url 'checkout' order.uuid %}" method="POST" class="card-body">
+
+              {% csrf_token %}
               <div class="mta_form">
                 <div class="row">
                   <div class="col-lg-4 col-md-12 mb-4">
@@ -64,7 +66,7 @@
                   </div>
                   <div class="col-lg-6 col-md-6 mb-6">
                     <label for="contactEmail">Contact Email</label>
-                    <input type='email' id='contactEmail' name='_replyto' class='form-control' required/>
+                    <input type='email' id='contactEmail' name='lab_email' class='form-control' required/>
                   </div>
                 </div>
 
@@ -151,7 +153,7 @@
               </div>
 
               <hr class="mb-4">
-              <button class="btn btn-primary btn-lg btn-block" type="submit">Continue to checkout</button>
+              <button class="btn btn-primary btn-lg btn-block" type="submit">Submit</button>
 
             </form>
 

--- a/fg/apps/orders/templates/shipping/create.html
+++ b/fg/apps/orders/templates/shipping/create.html
@@ -42,14 +42,6 @@ $( document ).ready(function() {
 
 $("#load-button").click(function() {
   if(typeof Storage !== "undefined") {
-      $("input[name='shipping_to']").val(localStorage.getItem('shipping_to'));
-      $("input[name='shipping_address']").val(localStorage.getItem('shipping_address'));
-      $("input[name='shipping_city']").val(localStorage.getItem('shipping_city'));
-      $("input[name='shipping_state']").val(localStorage.getItem('shipping_state'));
-      $("input[name='shipping_zip']").val(localStorage.getItem('shipping_zip'));
-      $("input[name='shipping_address2']").val(localStorage.getItem('shipping_address2'));   
-      $("input[name='shipping_phone']").val(localStorage.getItem('shipping_phone'));   
-
       $("input[name='from_name']").val(localStorage.getItem('from_name'));
       $("input[name='from_address']").val(localStorage.getItem('from_address'));
       $("input[name='from_zip']").val(localStorage.getItem('from_zip'));
@@ -78,14 +70,6 @@ $("form").submit(function(event) {
       localStorage.setItem('parcel_width', $("input[name='parcel_width']").val());
       localStorage.setItem('parcel_height', $("input[name='parcel_height']").val());
       localStorage.setItem('parcel_weight', $("input[name='parcel_weight']").val());
-
-      localStorage.setItem('shipping_to', $("input[name='shipping_to']").val());
-      localStorage.setItem('shipping_address', $("input[name='shipping_address']").val());
-      localStorage.setItem('shipping_zip', $("input[name='shipping_zip']").val());
-      localStorage.setItem('shipping_city', $("input[name='shipping_city']").val());
-      localStorage.setItem('shipping_state', $("input[name='shipping_state']").val());
-      localStorage.setItem('shipping_address2', $("input[name='shipping_address2']").val());
-      localStorage.setItem('shipping_phone', $("input[name='shipping_phone']").val());
    
       localStorage.setItem('from_city', $("input[name='from_city']").val());
       localStorage.setItem('from_state', $("input[name='from_state']").val());

--- a/fg/apps/orders/urls.py
+++ b/fg/apps/orders/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     url(r'^cart/add/(?P<uuid>.+)$', views.add_to_cart, name='add-to-cart'),
     url(r'^cart/remove/(?P<uuid>.+)$', views.remove_from_cart, name='remove-from-cart'),
     url(r'^checkout$', login_required(views.CheckoutView.as_view()), name='checkout'),
+    url(r'^checkout/(?P<uuid>.+)$', login_required(views.CheckoutView.as_view()), name='checkout'),
     url(r'^submit/(?P<uuid>.+)$', views.submit_order, name='submit_order'),
 
     # Material Transfer Agreement

--- a/fg/apps/orders/views/shipping.py
+++ b/fg/apps/orders/views/shipping.py
@@ -80,7 +80,17 @@ class ShippingView(View):
             messages.warning(self.request, "This order needs an MTA before proceeding.")
             return redirect('order_details', uuid=str(order.uuid))
  
-        form = ShippingForm()
+        # Populate fields with current order
+        address = order.shipping_address
+        shipping_to = "%s %s" %(address.recipient_title or '', address.recipient_name)
+        form = ShippingForm(initial={"shipping_to": shipping_to,
+                                     "shipping_address": address.address1,
+                                     "shipping_address2": address.address2,
+                                     "shipping_city": address.city,
+                                     "shipping_state": address.state,
+                                     "shipping_zip": address.postal_code,
+                                     "shipping_phone": address.phone,
+                                     "shipping_country": address.country})
         context = {
             'form': form,
             'order': order


### PR DESCRIPTION
This is a refactor of the order to shipment workflow, specifically we are:

 1. Saving lab and shipping address when a user submits an order, formspree is no longer used
 2. The lab_address and shipping_address are saved as a new model, Address, each of which is linked to fields for the order, lab_address and shipping_address, respectively. if the user has selected that the shipping address is the lab address, we save the same address to both fields.
 3. When this is done, the lab still receives an email notification, but this time via SendGrid. It looks like this:

![image](https://user-images.githubusercontent.com/814322/68344386-e390f100-00bc-11ea-8bf3-c91ff1ef6ab3.png)

Note that comments are now added (not previously there) in case there are special notes about the order.

  4. The lab can then click to go to the order, and click on "Create Shipment" as before.
  5. The shipment address fields are auto-populated from the saved shipping_address in the database.

Since the shipping address will come from the server, I've removed it from being cached on the page (clicking the load button will only load the from address that was previously used).

@Koeng101 this needs your review! It's almost 6pm here so I won't be working on it further, and I also wouldn't want to update the server and then not be able to respond immediately to any issues that might arise. Please take your time to review today / early tomorrow, and let's plan on updating the server sometime tomorrow when both of us are actively at the keyboard.