### PR TITLE
Refactoring order statuses

### DIFF
--- a/fg/apps/main/templates/details/order_details.html
+++ b/fg/apps/main/templates/details/order_details.html
@@ -42,7 +42,7 @@
           <td>Time Updated</td><td>{{ instance.time_updated }}</td>
         </tr>
         <tr>
-          <td>Status</td><td>{% if instance.ordered and instance.received %}Complete{% elif instance.ordered %}Processing{% else %}Cart{% endif %}</td>
+          <td>Status</td><td>{{ instance.status }} ({{ instance.summary_status }})</td>
         </tr>
         <tr>
           <td>Material Transfer Agreement</td><td>{% if instance.material_transfer_agreement %}Yes{% else %}No{% endif %}</td>

--- a/fg/apps/main/templates/tables/order_table.html
+++ b/fg/apps/main/templates/tables/order_table.html
@@ -5,17 +5,18 @@
                             <th>Status</th>
                             <th>Date Ordered</th>
                             <th>Date Shipped</th>
-                            <th>Signed MTA</th>
+                            <th>MTA</th>
                             <th>Notes</th>
                             <th>Distributions</th>
                         </tr>
                     </thead>
-                    <tbody>{% for order in orders %}{% if order.ordered or order.received %}
+                    <tbody>{% for order in orders %}{% if order.status != "Cart" %}
                         <tr>
                             <td><a href="{{ order.get_absolute_url }}">{{ order.name }}</a></td>
-                            <td>{% if order.received %}Complete{% else %}Processing{% endif %}</td>
+                            <td>{{ order.status }}<br>({{ order.summary_status }})</td>
                             <td>{{ order.date_ordered | date:'Y-m-d' }}</td>
-                            <td>{% if order.date_shipped %}{{ order.date_shipped | date:'Y-m-d' }}{% else %}{% if request.user.is_staff or request.user.is_superuser %}{% if order.received %}<a href="{% url 'mark_as_shipped' order.uuid %}"><button class="btn btn-secondary btn-sm">Mark Shipped</button></a>{% endif %}{% endif %}{% endif %}</td>
+                            <td>{% if order.date_shipped %}{{ order.date_shipped | date:'Y-m-d' }}{% else %}
+{% if request.user.is_staff or request.user.is_superuser %}{% if order.status == "Waiting to Ship" %}<a href="{% url 'mark_as_shipped' order.uuid %}"><button class="btn btn-secondary btn-sm">Mark Shipped</button></a>{% endif %}{% if order.status != "Rejected" %}<a href="{% url 'mark_as_rejected' order.uuid %}"><button class="btn btn-secondary btn-sm">Reject</button></a>{% endif %}{% endif %}{% endif %}</td>
                             <td>{% if order.material_transfer_agreement %}Yes{% else %}No{% endif %}</td>
                             <td>{{ order.notes }}</td>
                             <td>{% for dist in order.distributions.all %}<a href="{{ dist.get_absolute_url }}">{{ dist.name }}</a>{% endfor %}</td>

--- a/fg/apps/orders/admin.py
+++ b/fg/apps/orders/admin.py
@@ -13,9 +13,9 @@ from fg.apps.orders.models import Order
 
 class OrderAdmin(admin.ModelAdmin):
     exclude = ('transaction', 'label', 'user', )
-    list_display = ('name', 'user', 'received', 'date_ordered', 'date_shipped', 'material_transfer_agreement', )
+    list_display = ('name', 'user', 'status', 'summary_status', 'date_ordered', 'date_shipped', 'material_transfer_agreement', )
     list_display_links = ('user', 'material_transfer_agreement', )
-    list_filter = ['received']
+    list_filter = ['status']
     search_fields = [
         'user__username',
         'ref_code'

--- a/fg/apps/orders/templates/orders/orders.html
+++ b/fg/apps/orders/templates/orders/orders.html
@@ -32,7 +32,7 @@
 <script>
 $(document).ready(function() {
   {% if cart %}$("#cart-table").DataTable();{% endif %}
-  {% if orders %}$("#order-table").DataTable();{% endif %}
+  {% if orders %}$("#order-table").DataTable({pageLength:50});{% endif %}
 });
 </script>
 {% endblock %}

--- a/fg/apps/orders/templates/orders/table.html
+++ b/fg/apps/orders/templates/orders/table.html
@@ -18,8 +18,7 @@
             <td>{{ item.description }}</td>
             <td>{{ item.platesets.count }}</td>
             <td>
-            {% if request.user.is_superuser or request.user.is_staff %}<a href="{% url 'admin:main_distribution_change' item.uuid %}">
-<button class="btn btn-primary btn-sm" style='margin:0px'>Edit</button></a>{% endif %}
+            {% if request.user.is_superuser or request.user.is_staff %}<a href="{% url 'admin:main_distribution_change' item.uuid %}"><button class="btn btn-primary btn-sm" style='margin:0px'>Edit</button></a>{% endif %}
             <a href="{% url 'remove-from-cart' item.uuid %}">
                 <i style="color:#CCC" class="fas fa-trash float-right"></i>
             </a>

--- a/fg/apps/orders/templatetags/cart_template_tags.py
+++ b/fg/apps/orders/templatetags/cart_template_tags.py
@@ -17,7 +17,7 @@ register = template.Library()
 def cart_item_count(user):
     if user.is_authenticated:
         try:
-            cart = Order.objects.get(user=user, ordered=False)
+            cart = Order.objects.get(user=user, status="Cart")
         except Order.DoesNotExist:
             return 0
         return cart.distributions.count()

--- a/fg/apps/orders/urls.py
+++ b/fg/apps/orders/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     url(r'^shipment/create/(?P<uuid>.+)$', login_required(views.ShippingView.as_view()), name='create_shipment'),
     url(r'^shipment/import-shippo-order$', login_required(views.ImportShippoView.as_view()), name='import_shippo_order'),
     url(r'^shipment/mark-shipped/(?P<uuid>.+)$', views.mark_as_shipped, name='mark_as_shipped'),
+    url(r'^shipment/reject/(?P<uuid>.+)$', views.mark_as_rejected, name='mark_as_rejected'),
     url(r'^transaction/create/(?P<uuid>.+)$', views.create_transaction, name='create_transaction'),
     url(r'^label/create/(?P<uuid>.+)$', views.create_label, name='create_label'),
 

--- a/fg/apps/orders/views/__init__.py
+++ b/fg/apps/orders/views/__init__.py
@@ -15,6 +15,7 @@ from .orders import (
 from .shipping import (
     create_label,
     create_transaction,
+    mark_as_rejected,
     mark_as_shipped,
     ImportShippoView,
     ShippingView

--- a/fg/apps/users/models.py
+++ b/fg/apps/users/models.py
@@ -81,8 +81,7 @@ class User(AbstractUser):
            is only allowed one order with this status and their association.
         '''
         for order in self.order_set.all():
-            # if the order isn't ordered, it's the cart.
-            if not order.ordered:
+            if order.status == "Cart":
                 return order
 
     def get_cart_items(self):


### PR DESCRIPTION
This is a fairly large set of changes to address #126. Specifically:

## Addition of order.status
We are removing order.ordered and order.received (two booleans) in favor of a single order.status, which can be any of:

 - Cart (a new order that isn't submit yet, the user's cart). When the user first adds a distribution and doesn't have a cart, this one is created.
 - Rejected: indicates that the lab has chosen to not process further. The button appears in the orders table (given lab staff) unless the order has already been rejected.
 - Awaiting Countersign: is the default status,  
 - Generating Label: indicates that the countersigned MTA has been uploaded (by the lab staff). Conversely, if the user re-uploads an MTA via that same form, the status goes back to Awaiting Countersign.
 - Waiting to Ship: indicates that the label has been generated, but not sent out yet
 - Shipped: is the status given when the lab clicks "Mark as Shipped." This almost has to be manual, since it's a human doing it :)

Importantly, the default status is *not* Cart, because doing so when we migrate would make Cart the default status for all orders, and this would hugely break things because we set a create limit on a user only having one cart. For this reason, the default status is "Awaiting Countersign" which means that any current Carts are also going to show up as orders. Here is how this can be handled:

 - Current orders that aren't yet received or processed (the user's carts) should likely be entirely deleted, otherwise they will be given default status "Awaiting Countersign" even though they aren't submit.
 - If an order that isn't received or processed isn't deleted, the migration needs to happen and it's status changed to "Cart" immediately.

As an example, when I run the migrations locally, here is a (previous cart) that now has status as an order Awaiting Countersign, meaning that it would show up in the table (erroneously):

```python
from fg.apps.orders.models import *
order = Order.objects.first()                                                                       

order.status 
# 'Awaiting Countersign'
```
Here is a snapshot of the updated table - anything that isn't a Cart (order.status == "Cart") is shown, and any order that isn't already rejected can be rejected at any step.

![image](https://user-images.githubusercontent.com/814322/68531066-6cd23e80-02dc-11ea-8a60-b1a8b07fb861.png)

and here is how it renders in the admin table

![image](https://user-images.githubusercontent.com/814322/68531168-6ee8cd00-02dd-11ea-9f7c-ef761408f13b.png)

## Adding property summary_status

For easy filtering between Processing and Completed, we have a `summary_status` property that will
return if it's Processing, Complete, or Cart. It's calculated based on order.status. For example, for the order above:

```python
order.summary_status                                                                                
# 'Processing'
```

## Summary

In summary, for this PR to be good we need to do the following:

 - @Koeng101 and @hverdonk please review the changes below in full. Note that:
    -  I've added additional status "Cart" and final status "Shipped" instead of "Complete," and both Shipped/Rejected map to a summary status of Completed.
    - the status field renders as <detailed status> (<summary status>)
    - any order that isn't a Cart shows up in the orders table
 - when the changes are good, we need to (ideally) remove user carts, this shouldn't be too bad I currently only see three, two of which are likely testing carts:
```python
[x.user for x in Order.objects.filter(ordered=False,received=False)]    
[<User: nick>, <User: vsoch>, <User: marc4-stanford>]
```
For the nick user, we could notify him (or just leave as is and change to status = Cart after. Let me know your preference (I can do this querying when I update if you tell me exactly the plan you've decided on).

 - Once the current carts are known / removed, then we can merge the changes and migrate the database. We take a deep breath that there isn't any issue with removing the order.received and order.ordered fields (I had no issue locally) and then restart the server!

At that point, the changes should be live, and @hverdonk existing orders will need to be manually updated with their correct statuses (which likely you know?) At this point we can move forward with discussion for #128 and #127. 


Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>