### PR TITLE
Added import of Sample to generate_sample_entry

### DIFF
--- a/fg/apps/factory/views/factory.py
+++ b/fg/apps/factory/views/factory.py
@@ -359,6 +359,7 @@ def import_plates_task(data, container):
 def generate_sample_entry(sampleEntry, part):
     '''generate a sample from an entry
     '''
+    from fg.apps.main.models import Sample
     created = False
     try:
         sample = Sample.objects.get(uuid=sampleEntry['uuid'])


### PR DESCRIPTION
I encountered the following error:

```Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/ratelimit/decorators.py", line 30, in _wrapped
    return fn(*args, **kw)
  File "./fg/apps/factory/views/factory.py", line 114, in import_factory_plate
    message = import_plates_task(data, container)
  File "./fg/apps/factory/views/factory.py", line 298, in import_plates_task
    sample, created = generate_sample_entry(sampleEntry, part)
  File "./fg/apps/factory/views/factory.py", line 365, in generate_sample_entry
    except Sample.DoesNotExist:
NameError: name 'Sample' is not defined
```

I'm assuming this is because Sample was not imported in the function generate_sample_entry, so I added it as an import.