### PR TITLE
Added default sample status to Twist plate import

### DIFF
--- a/fg/apps/factory/views/twist.py
+++ b/fg/apps/factory/views/twist.py
@@ -377,7 +377,8 @@ def import_plate_task(rows, fields, factory_order):
                 # If we didn't find a sample already associated with the Factory order, create it
                 if not sample:
                     sample = Sample.objects.create(vendor=factory_order.vendor.name,
-                                                   part=part)
+                                                   part=part, sample_evidence='Twist_Confirmed',
+                                                   sample_status='Confirmed')
   
                 sample.save()
                 sample.wells.add(well)

--- a/fg/apps/factory/views/twist.py
+++ b/fg/apps/factory/views/twist.py
@@ -377,8 +377,8 @@ def import_plate_task(rows, fields, factory_order):
                 # If we didn't find a sample already associated with the Factory order, create it
                 if not sample:
                     sample = Sample.objects.create(vendor=factory_order.vendor.name,
-                                                   part=part, sample_evidence='Twist_Confirmed',
-                                                   sample_status='Confirmed')
+                                                   part=part, evidence='Twist_Confirmed',
+                                                   status='Confirmed')
   
                 sample.save()
                 sample.wells.add(well)


### PR DESCRIPTION
Samples, when imported through the Twist Plate Import system, do not have proper defaults. This sets those defaults properly